### PR TITLE
Add jest-prop-type-error as dep

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,8 @@ const config = {
   roots: ['<rootDir>/src/'],
   setupFiles: [
     '<rootDir>/src/test/jest-setup.js',
-    '<rootDir>/src/test/enzyme-setup.js'
+    '<rootDir>/src/test/enzyme-setup.js',
+    'jest-prop-type-error'
   ],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   testMatch: ['<rootDir>/src/**/test-*.js'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -8297,6 +8297,12 @@
       "integrity": "sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=",
       "dev": true
     },
+    "jest-prop-type-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jest-prop-type-error/-/jest-prop-type-error-1.1.0.tgz",
+      "integrity": "sha512-i/4hdbKSp6cFJc2z3Blu2WEOGjxbQ76pShhtDFIqUfdC8ruMGT57EOsBtBq69FVg915MUMwENNc185ejs7mmtg==",
+      "dev": true
+    },
     "jest-regex-util": {
       "version": "23.3.0",
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-23.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-react": "^7.11.1",
     "husky": "^1.1.4",
     "jest": "^23.6.0",
+    "jest-prop-type-error": "^1.1.0",
     "mutation-observer": "^1.0.3",
     "node-sass": "^4.9.4",
     "prettier": "1.15.2",


### PR DESCRIPTION
## Done

Added `jest-prop-type-error` as a dep so any instances where a component recieves a proper inconsistent with the PropType declaration, a test failure will throw.

## QA

- Run feature branch
- Run `npm test` - verify all tests pass
- Change a PropType in one of the components, e.g. in `Button.js` - change line 61 to; `submit: PropTypes.string,`
- Run `npm test` again and verify an error is thrown

Fixes #26 